### PR TITLE
Input automatically focuses if there aren't any search results present

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -157,7 +157,7 @@
       `,
       label: 'Search results',
       id: 'search',
-      component: html`<ia-book-search-results .query=${'bristol'} ?renderHeader=${false} ?renderSearchAllFiles=${false}></ia-book-search-results>`,
+      component: html`<ia-book-search-results .query=${''} ?renderHeader=${false} ?renderSearchAllFiles=${false}></ia-book-search-results>`,
     };
     menuSlider.menus = [searchMenu];
     menuSlider.open = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-search-results",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-search-results",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Book search results pane for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/src/ia-book-search-results.js
+++ b/src/ia-book-search-results.js
@@ -38,9 +38,7 @@ export class IABookSearchResults extends LitElement {
     this.bindBookReaderListeners();
   }
 
-  /**
-   * lifecycle method to adjust behavior post-render
-   */
+  /** @inheritdoc */
   updated() {
     this.focusOnInputIfNecessary();
   }

--- a/src/ia-book-search-results.js
+++ b/src/ia-book-search-results.js
@@ -20,7 +20,6 @@ export class IABookSearchResults extends LitElement {
       renderHeader: { type: Boolean },
       renderSearchAllFiles: { type: Boolean },
       displayResultImages: { type: Boolean },
-      focusInputIfPossible: { type: Boolean },
       errorMessage: { type: String },
     };
   }
@@ -34,7 +33,6 @@ export class IABookSearchResults extends LitElement {
     this.renderHeader = false;
     this.renderSearchAllFields = false;
     this.displayResultImages = false;
-    this.focusInputIfPossible = true;
     this.errorMessage = '';
 
     this.bindBookReaderListeners();

--- a/src/ia-book-search-results.js
+++ b/src/ia-book-search-results.js
@@ -14,15 +14,14 @@ export class IABookSearchResults extends LitElement {
 
   static get properties() {
     return {
+      results: { type: Array },
       query: { type: String },
       queryInProgress: { type: Boolean },
       renderHeader: { type: Boolean },
       renderSearchAllFiles: { type: Boolean },
       displayResultImages: { type: Boolean },
+      focusInputIfPossible: { type: Boolean },
       errorMessage: { type: String },
-      results: {
-        type: Array,
-      },
     };
   }
 
@@ -30,17 +29,37 @@ export class IABookSearchResults extends LitElement {
     super();
 
     this.results = [];
+    this.query = '';
     this.queryInProgress = false;
     this.renderHeader = false;
     this.renderSearchAllFields = false;
     this.displayResultImages = false;
+    this.focusInputIfPossible = true;
     this.errorMessage = '';
 
     this.bindBookReaderListeners();
   }
 
+  /**
+   * lifecycle method to adjust behavior post-render
+   */
+  updated() {
+    this.focusOnInputIfNecessary();
+  }
+
   bindBookReaderListeners() {
     document.addEventListener('BookReader:SearchCallback', this.setResults.bind(this));
+  }
+
+  /**
+   * Provide immediate input focus if there aren't any results displayed
+   */
+  focusOnInputIfNecessary() {
+    if (this.results.length) {
+      return;
+    }
+    const searchInput = this.shadowRoot.querySelector('input[type=\'search\']');
+    searchInput.focus();
   }
 
   setResults({ detail }) {
@@ -134,7 +153,13 @@ export class IABookSearchResults extends LitElement {
       <form action="" method="get" @submit=${this.performSearch}>
         <fieldset>
           ${this.searchMultipleControls}
-          <input type="search" name="query" @keyup=${this.setQuery} .value=${this.query} />
+          <input
+            type="search"
+            name="query"
+            alt="Search inside this book."
+            @keyup=${this.setQuery}
+            .value=${this.query}
+          />
         </fieldset>
       </form>
     `;

--- a/test/ia-book-search-results.test.js
+++ b/test/ia-book-search-results.test.js
@@ -194,6 +194,27 @@ describe('<ia-book-search-results>', () => {
 
     expect(el.shadowRoot.querySelector('.results.show-image')).to.exist;
   });
+
+  describe('search input focus', () => {
+    it('will always try to re-focus once the component updates', async () => {
+      const el = await fixture(container(results));
+      el.focusOnInputIfNecessary = sinon.fake();
+      // update any property to fire lifecycle
+      el.results = [];
+      await el.updateComplete;
+
+      expect(el.focusOnInputIfNecessary.callCount).to.equal(1);
+    });
+    it('refocuses on input when results are empty', async () => {
+      const el = await fixture(container(results));
+      el.results = [];
+      await el.updateComplete;
+
+      const searchInputField = el.shadowRoot.querySelector('input[type=\'search\']');
+      expect(searchInputField).to.equal(el.shadowRoot.activeElement);
+    });
+  });
+
   // it("emits a bookSearchCanceled event when loading state's cancel action clicked", async () => {
   //   const el = await fixture(container(results));
 


### PR DESCRIPTION
To reduce user clicks to get to search inside input, we will bring the search input to focus when there aren't any search results

Test full flow:
- go to https://www-isa.archive.org/details/whole_earth_review_75/page/n114
- you see search icon as a menu shortcut -> open it
- once menu is open, your cursor is already focused in the search input
- search: `Mark Carranza`
- close menu while search is happening
- open menu again when search is complete
- cursor is not focused in the search input field as the search has 1 or more results

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/7840857/97205415-b7123100-1774-11eb-96cb-aa1ed423eb09.gif)
