### PR TITLE
Add Search CTA placeholder when results are empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-search-results",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-search-results",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Book search results pane for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/src/ia-book-search-results.js
+++ b/src/ia-book-search-results.js
@@ -167,7 +167,13 @@ export class IABookSearchResults extends LitElement {
     `;
   }
 
+  get searchCTA() {
+    return html`<p class="search-cta"><em>Please enter text to search for</em></p>`;
+  }
+
   render() {
+    const showSearchCTA = (!this.queryInProgress && !this.errorMessage)
+    && (!this.queryInProgress && !this.results.length);
     return html`
       ${this.headerSection}
       ${this.searchForm}
@@ -175,6 +181,7 @@ export class IABookSearchResults extends LitElement {
         ${this.queryInProgress ? this.loadingIndicator : nothing}
         ${this.errorMessage ? this.setErrorMessage : nothing}
         ${this.results.length ? this.resultsSet : nothing}
+        ${showSearchCTA ? this.searchCTA : nothing}
       </div>
     `;
   }

--- a/src/styles/ia-book-search-results.js
+++ b/src/styles/ia-book-search-results.js
@@ -69,7 +69,7 @@ label.checkbox:after {
 
 [type="search"] {
   -webkit-appearance: textfield;
-  width: 98%;
+  width: 100%;
   height: 3rem;
   padding: 0 1.5rem;
   box-sizing: border-box;
@@ -97,6 +97,10 @@ label.checkbox:after {
 p.page-num {
   font-weight: bold;
   padding-bottom: 0;
+}
+
+p.search-cta {
+  text-align: center;
 }
 
 .results-container {

--- a/test/ia-book-search-results.test.js
+++ b/test/ia-book-search-results.test.js
@@ -169,22 +169,31 @@ describe('<ia-book-search-results>', () => {
     expect(response).to.exist;
   });
 
-  it('renders a loading state when queryInProgress is true', async () => {
-    const el = await fixture(container(results));
+  describe('Search results placeholders', () => {
+    it('renders a loading state when queryInProgress is true', async () => {
+      const el = await fixture(container(results));
 
-    el.queryInProgress = true;
-    await el.updateComplete;
+      el.queryInProgress = true;
+      await el.updateComplete;
 
-    expect(el.shadowRoot.querySelector('.loading')).to.not.be.null;
-  });
+      expect(el.shadowRoot.querySelector('.loading')).to.not.be.null;
+    });
+    it('renders an error message when provided', async () => {
+      const el = await fixture(container([]));
+      const message = 'Sample error message';
+      el.errorMessage = message;
+      await el.updateComplete;
 
-  it('renders an error message when provided', async () => {
-    const el = await fixture(container([]));
-    const message = 'Sample error message';
-    el.errorMessage = message;
-    await el.updateComplete;
+      expect(el.shadowRoot.querySelector('.error-message')).to.exist;
+      expect(el.shadowRoot.querySelector('.search-cta')).to.be.null;
+    });
+    it('displays call to search when no results or search errors are showing', async () => {
+      const el = await fixture(container([]));
 
-    expect(el.shadowRoot.querySelector('.error-message')).to.exist;
+      expect(el.shadowRoot.querySelector('.search-cta')).to.exist;
+      expect(el.shadowRoot.querySelector('.error-message')).to.be.null;
+      expect(el.shadowRoot.querySelector('.results')).to.be.null;
+    });
   });
 
   it('displays results images when told to', async () => {


### PR DESCRIPTION
Adds a call to search when no results or error messages are displayed.

![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/7840857/98852412-7d942380-240c-11eb-97c2-de4a12fc6b56.gif)

https://webarchive.jira.com/browse/WEBDEV-3985
